### PR TITLE
reproducible builds by using fixed git revisions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,8 @@ license=  "MIT / Apache-2.0"
 name = "fontconfig"
 
 [dependencies]
-servo-fontconfig-sys = { git = "https://github.com/jwilm/libfontconfig" }
 libc = "0.2"
+
+[dependencies.servo-fontconfig-sys]
+git = "https://github.com/jwilm/libfontconfig"
+rev = "618a52973d46e5cce4f054f6ee3bd2682167eee4"


### PR DESCRIPTION
This is required for packaging in [nixpkgs](https://nixos.org/), which is build
around deterministic builds and breaks if dependencies changes silently.